### PR TITLE
make dns setting also aware of blacklisted apps

### DIFF
--- a/scripts/clash.tproxy
+++ b/scripts/clash.tproxy
@@ -69,6 +69,11 @@ create_nat_prerouting_dns() {
 create_nat_output_dns() {
     ${iptables_wait} -t nat -N DNS_OUT
 
+    if [ "${mode}" = "blacklist" ] ; then
+        for appuid in `cat ${appuid_file} | sort -u` ; do
+            ${iptables_wait} -t nat -A DNS_OUT -p udp -m owner --uid-owner ${appuid} -j ACCEPT
+        done
+    fi
     ${iptables_wait} -t nat -A DNS_OUT -p udp -j REDIRECT --to-ports ${Clash_dns_port}
 }
 
@@ -99,7 +104,7 @@ apply_rules() {
 
     create_mangle_output_chain
     create_mangle_output_filter
-    
+
     create_nat_prerouting_dns
     create_nat_prerouting_filter
 
@@ -160,7 +165,7 @@ flush_rules() {
     ${iptables_wait} -t mangle -X FILTER_PRE_CLASH
     ${iptables_wait} -t mangle -F CLASH_PRE
     ${iptables_wait} -t mangle -X CLASH_PRE
-    
+
     echo "info: iptables规则已清空." >> ${CFM_logs_file}
 }
 


### PR DESCRIPTION
Currently, all dns queries go through the clash, but the blacklisted
apps unnecessary.